### PR TITLE
Fix for csv file not being packaged by pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include zoltpy/locations.csv

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setuptools.setup(
     description="A package of Reich Lab Zoltar utility functions.",
     long_description=long_description,
     long_description_content_type="text/markdown",
+    include_package_data=True,
     url="https://github.com/reichlab/zoltpy",
     packages=setuptools.find_packages(),
     classifiers=[


### PR DESCRIPTION
## Description
`pip` does not package any non-code files by default. Following [this](https://python-packaging.readthedocs.io/en/latest/non-code-files.html) guide and added the necessary changes to make `locations.csv` file being packaged by pip. 