### PR TITLE
[change quantile file validation to allow zero point predictions per …

### DIFF
--- a/tests/quantile-predictions-no-point.csv
+++ b/tests/quantile-predictions-no-point.csv
@@ -1,6 +1,5 @@
 target,location,type,quantile,value
 1 wk ahead cum death,02,point,NA,7.74526423651839
-1 day ahead inc hosp,01,quantile,0.01,46.0743989840204
 1 day ahead inc hosp,US,point,NA,90717
 1 day ahead inc hosp,51,quantile,0.01,9
 1 day ahead inc hosp,51,quantile,0.025,15

--- a/tests/test_quantile_io.py
+++ b/tests/test_quantile_io.py
@@ -219,7 +219,7 @@ class QuantileIOTestCase(TestCase):
                                    "class. Found these duplicate unit/target/classes tuples: [('04', '1 day ahead "
                                    "inc hosp', ['point', 'point'])]"),
                                   (MESSAGE_QUANTILES_AS_A_GROUP,
-                                   "There must be exactly one point prediction for each location/target pair. Found "
+                                   "There must be zero or one point predictions for each location/target pair. Found "
                                    "these unit, target, point counts tuples did not have exactly one point: [('04', "
                                    "'1 day ahead inc hosp', 2)]")]
             self.assertEqual(exp_error_messages, act_error_messages)
@@ -229,10 +229,7 @@ class QuantileIOTestCase(TestCase):
         with open('tests/quantile-predictions-no-point.csv') as quantile_fp:
             _, error_messages = json_io_dict_from_quantile_csv_file(quantile_fp, ['1 day ahead inc hosp',
                                                                                   '1 wk ahead cum death'])
-            self.assertEqual(1, len(error_messages))
-            self.assertEqual(MESSAGE_QUANTILES_AS_A_GROUP, error_messages[0][0])
-            self.assertIn("There must be exactly one point prediction for each location/target pair",
-                          error_messages[0][1])
+            self.assertEqual(0, len(error_messages))
 
 
     def test_json_io_dict_from_point_csv_file_bad_values(self):

--- a/zoltpy/quantile_io.py
+++ b/zoltpy/quantile_io.py
@@ -143,13 +143,13 @@ def json_io_dict_from_quantile_csv_file(csv_fp, valid_target_names, row_validato
     # validate: "There must be exactly one point prediction for each location/target pair"
     unit_target_point_count = [(unit, target, pred_classes.count('point')) for (unit, target), pred_classes
                                in loc_targ_to_pred_classes.items()
-                               if pred_classes.count('point') != 1]
+                               if pred_classes.count('point') > 1]
     if unit_target_point_count:
         if len(unit_target_point_count) > 10:  # pick first 10 tuples to reduce output
             unit_target_point_count = unit_target_point_count[:10] + ['...']
         error_messages.append((MESSAGE_QUANTILES_AS_A_GROUP,
-                               f"There must be exactly one point prediction for each location/target pair. Found these "
-                               f"unit, target, point counts tuples did not have exactly one point: "
+                               f"There must be zero or one point predictions for each location/target pair. Found "
+                               f"these unit, target, point counts tuples did not have exactly one point: "
                                f"{unit_target_point_count}"))
 
     # done


### PR DESCRIPTION
Implements #53 [change quantile file validation to allow zero point predictions per unit/target pair #53]. As part of this I need to edit https://github.com/reichlab/covid19-forecast-hub/wiki/Forecast-Checks to read:

- validates quantiles as a group:
    - there must be zero or one point prediction for each location/target pair

test results:
> Ran 46 tests in 0.590s
> OK